### PR TITLE
CBMC proof for SigV4_GenerateHTTPAuthorization()

### DIFF
--- a/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/README.md
+++ b/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/README.md
@@ -1,0 +1,20 @@
+SigV4_GenerateHTTPAuthorization proof
+==============
+
+This directory contains a memory safety proof for SigV4_GenerateHTTPAuthorization.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/cbmc-proof.txt
+++ b/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/cbmc-viewer.json
+++ b/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "SigV4_GenerateHTTPAuthorization",
+  "proof-root": "test/cbmc/proofs"
+}


### PR DESCRIPTION
*Description of changes:* Add CBMC proof for SigV4_GenerateHTTPAuthorization().


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
