### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,0 +1,114 @@
+name: Release automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Commit ID to tag and create a release for'
+        required: true
+      version_number:
+        description: 'Release Version Number (Eg, v1.0.0)'
+        required: true
+
+jobs:
+  tag-commit:
+    name: Tag commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+      - name: Configure git identity
+        run: |
+            git config --global user.name "Release Workflow"
+      - name: Tag Commit and Push to remote
+        run: |
+          git tag ${{ github.event.inputs.version_number }} -a -m "AWS IoT SigV4 ${{ github.event.inputs.version_number }}"
+          git push origin --tags
+      - name: Verify tag on remote
+        run: |
+          git tag -d ${{ github.event.inputs.version_number }}
+          git remote update
+          git checkout tags/${{ github.event.inputs.version_number }}
+          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+  create-zip:
+    needs: tag-commit
+    name: Create ZIP and verify package for release asset.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install ZIP tools
+        run: sudo apt-get install zip unzip
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+          path: SigV4-for-AWS-IoT-embedded-sdk
+          submodules: recursive
+      - name: Checkout disabled submodules
+        run: |
+          cd SigV4-for-AWS-IoT-embedded-sdk
+          git submodule update --init --checkout --recursive
+      - name: Create ZIP
+        run: |
+          zip -r SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip SigV4-for-AWS-IoT-embedded-sdk -x "*.git*"
+          ls ./
+      - name: Validate created ZIP
+        run: |
+          mkdir zip-check
+          mv SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip zip-check
+          cd zip-check
+          unzip SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip -d SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}
+          ls SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}
+          diff -r -x "*.git*" SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}/SigV4-for-AWS-IoT-embedded-sdk/ ../SigV4-for-AWS-IoT-embedded-sdk/
+          cd ../
+      - name: Build
+        run: |
+          cd zip-check/SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}/SigV4-for-AWS-IoT-embedded-sdk
+          sudo apt-get install -y lcov
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          make -C build/ all
+      - name: Test
+        run: |
+          cd zip-check/SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}/SigV4-for-AWS-IoT-embedded-sdk/build/
+          ctest -E system --output-on-failure
+          cd ..
+      - name: Create artifact of ZIP
+        uses: actions/upload-artifact@v2
+        with:
+          name: SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+          path: zip-check/SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+  create-release:
+    needs: create-zip
+    name: Create Release and Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version_number }}
+          release_name: ${{ github.event.inputs.version_number }}
+          body: Release ${{ github.event.inputs.version_number }} of AWS IoT SigV4.
+          draft: false
+          prerelease: false
+      - name: Download ZIP artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+          asset_name: SigV4-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+          asset_content_type: application/zip

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,21 @@
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so.
+Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
*Description of changes:* **A)** Porting a copy of the release workflow found in all spoke repositories, and **B)** reverting previous [revision ](https://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk/commit/3eeec7c1c9fb80a1a8f62b4c3d7fb70eba6c1a4f#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7)to LICENSE file, following further discussion on its standardization.

The release script, and all generated assets, were verified using this manually triggered job run on a fork : https://github.com/sukhmanm/SigV4-for-AWS-IoT-embedded-sdk/actions/runs/1031316215. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
