### PR TITLE
Add more MISRA fixes

### DIFF
--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -9,12 +9,12 @@
     </tr>
     <tr>
         <td>sigv4.c</td>
-        <td><center>4.9K</center></td>
+        <td><center>4.8K</center></td>
         <td><center>4.2K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>4.9K</center></b></td>
+        <td><b><center>4.8K</center></b></td>
         <td><b><center>4.2K</center></b></td>
     </tr>
 </table>

--- a/source/include/sigv4.h
+++ b/source/include/sigv4.h
@@ -216,7 +216,7 @@ typedef struct SigV4CryptoInterface
      * @return Zero on success, all other return values are failures.
      */
     int32_t ( * hashUpdate )( void * pHashContext,
-                              const char * pInput,
+                              const uint8_t * pInput,
                               size_t inputLen );
 
     /**
@@ -233,7 +233,7 @@ typedef struct SigV4CryptoInterface
      * @return Zero on success, all other return values are failures.
      */
     int32_t ( * hashFinal )( void * pHashContext,
-                             char * pOutput,
+                             uint8_t * pOutput,
                              size_t outputLen );
 
     /**

--- a/source/include/sigv4_internal.h
+++ b/source/include/sigv4_internal.h
@@ -119,6 +119,11 @@
     }
 
 /**
+ * @brief A helper macro to test if a flag is set.
+ */
+#define FLAG_IS_SET( bits, flag )    ( ( ( bits ) & ( flag ) ) == ( flag ) )
+
+/**
  * @brief An aggregator representing the individually parsed elements of the
  * user-provided date parameter. This is used to verify the complete date
  * representation, and construct the final ISO 8601 string.

--- a/source/include/sigv4_internal.h
+++ b/source/include/sigv4_internal.h
@@ -113,10 +113,10 @@
  * @brief A helper macro to print insufficient memory errors.
  */
 #define LOG_INSUFFICIENT_MEMORY_ERROR( purposeOfWrite, bytesExceeded )                       \
-    do {                                                                                     \
+    {                                                                                        \
         LogError( ( "Insufficient memory provided to " purposeOfWrite ", bytesExceeded=%lu", \
                     ( unsigned long ) ( bytesExceeded ) ) );                                 \
-    } while( 0 )
+    }
 
 /**
  * @brief An aggregator representing the individually parsed elements of the
@@ -196,7 +196,7 @@ typedef struct HmacContext
     /**
      * @brief All accumulated key data.
      */
-    char key[ SIGV4_HASH_MAX_BLOCK_LENGTH ];
+    uint8_t key[ SIGV4_HASH_MAX_BLOCK_LENGTH ];
 
     /**
      * @brief The length of the accumulated key data.

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -362,7 +362,7 @@ static void setQueryParameterValue( size_t currentParameter,
  * @return Zero on success, all other return values are failures.
  */
 static int32_t hmacKey( HmacContext_t * pHmacContext,
-                        const char * pKey,
+                        const uint8_t * pKey,
                         size_t keyLen );
 
 /**
@@ -432,9 +432,9 @@ static int32_t completeHmac( HmacContext_t * pHmacContext,
  * @param[in] pCryptoInterface The interface used to call hash functions.
  * @return Zero on success, all other return values are failures.
  */
-static int32_t completeHash( const char * pInput,
+static int32_t completeHash( const uint8_t * pInput,
                              size_t inputLen,
-                             char * pOutput,
+                             uint8_t * pOutput,
                              size_t outputLen,
                              const SigV4CryptoInterface_t * pCryptoInterface );
 
@@ -1359,12 +1359,12 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
         if( isspace( value[ index ] ) )
         {
             /* The last character is a trailing space. */
-            if( ( index + 1 ) == valLen )
+            if( ( index + 1U ) == valLen )
             {
                 ret = true;
             }
             /* Trim if the next character is also a space. */
-            else if( isspace( value[ index + 1 ] ) )
+            else if( isspace( value[ index + 1U ] ) )
             {
                 ret = true;
             }
@@ -1579,7 +1579,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
             }
             /* Look for header value part of a header field entry for both canonicalized and non-canonicalized forms. */
             /* Non-canonicalized headers will have header values ending with "\r\n". */
-            else if( ( !keyFlag ) && !( flags & SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) && ( ( index + 1 ) < headersDataLen ) &&
+            else if( ( !keyFlag ) && !( flags & SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) && ( ( index + 1U ) < headersDataLen ) &&
                      ( 0 == strncmp( pCurrLoc, "\r\n", strlen( "\r\n" ) ) ) )
             {
                 canonicalRequest->pHeadersLoc[ noOfHeaders ].value.pData = pKeyOrValStartLoc;
@@ -2045,9 +2045,9 @@ static SigV4Status_t verifySigV4Parameters( const SigV4Parameters_t * pParams )
 
 /*-----------------------------------------------------------*/
 
-static int32_t completeHash( const char * pInput,
+static int32_t completeHash( const uint8_t * pInput,
                              size_t inputLen,
-                             char * pOutput,
+                             uint8_t * pOutput,
                              size_t outputLen,
                              const SigV4CryptoInterface_t * pCryptoInterface )
 {
@@ -2087,7 +2087,7 @@ static SigV4Status_t completeHashAndHexEncode( const char * pInput,
 {
     SigV4Status_t returnStatus = SigV4Success;
     /* Used to store the hash of the request payload. */
-    char hashBuffer[ SIGV4_HASH_MAX_DIGEST_LENGTH ];
+    uint8_t hashBuffer[ SIGV4_HASH_MAX_DIGEST_LENGTH ];
     SigV4String_t originalHash;
     SigV4String_t hexEncodedHash;
 
@@ -2103,9 +2103,9 @@ static SigV4Status_t completeHashAndHexEncode( const char * pInput,
     hexEncodedHash.pData = pOutput;
     hexEncodedHash.dataLen = *pOutputLen;
 
-    if( completeHash( pInput,
+    if( completeHash( ( const uint8_t * ) pInput,
                       inputLen,
-                      hashBuffer,
+                      ( uint8_t * ) hashBuffer,
                       pCryptoInterface->hashDigestLen,
                       pCryptoInterface ) != 0 )
     {
@@ -2128,7 +2128,7 @@ static SigV4Status_t completeHashAndHexEncode( const char * pInput,
 }
 
 static int32_t hmacKey( HmacContext_t * pHmacContext,
-                        const char * pKey,
+                        const uint8_t * pKey,
                         size_t keyLen )
 {
     int32_t returnStatus = 0;
@@ -2219,7 +2219,7 @@ static int32_t hmacData( HmacContext_t * pHmacContext,
         for( i = 0U; i < pCryptoInterface->hashBlockLen; i++ )
         {
             /* XOR the key with the ipad. */
-            pHmacContext->key[ i ] ^= ( char ) 0x36;
+            pHmacContext->key[ i ] ^= ( uint8_t ) 0x36;
         }
 
         returnStatus = pCryptoInterface->hashInit( pCryptoInterface->pHashContext );
@@ -2278,7 +2278,7 @@ static int32_t hmacFinal( HmacContext_t * pHmacContext,
          * inner-padded key with (0x36 ^ 0x5c) = (ipad ^ opad) = 0x6a.  */
         for( i = 0U; i < pCryptoInterface->hashBlockLen; i++ )
         {
-            pHmacContext->key[ i ] ^= ( char ) ( 0x6a );
+            pHmacContext->key[ i ] ^= ( uint8_t ) ( 0x6a );
         }
 
         returnStatus = pCryptoInterface->hashInit( pCryptoInterface->pHashContext );

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -632,7 +632,7 @@ static size_t sizeNeededForCredentialScope( const SigV4Parameters_t * pSigV4Para
  * @note This function can be used to copy a string literal without
  * MISRA warnings.
  *
- * @param[in] destination The buffer to write
+ * @param[in] destination The buffer to write.
  * @param[in] source String to copy.
  * @param[in] length Number of characters to copy.
  * @return @p length
@@ -1215,7 +1215,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
     static bool isAllowedChar( char c,
                                bool encodeSlash )
     {
-        return( ( isalnum( c ) != 0U ) || ( c == '-' ) || ( c == '_' ) || ( c == '.' ) || ( c == '~' ) || ( ( c == '/' ) && !encodeSlash ) );
+        return( ( isalnum( c ) != 0U ) || ( c == '-' ) || ( c == '_' ) || ( c == '.' ) || ( c == '~' ) || ( ( c == '/' ) && ( encodeSlash == false ) ) );
     }
 
 /*-----------------------------------------------------------*/

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -627,6 +627,20 @@ static SigV4Status_t lowercaseHexEncode( const SigV4String_t * pInputStr,
  */
 static size_t sizeNeededForCredentialScope( const SigV4Parameters_t * pSigV4Params );
 
+/**
+ * @brief Copy a string into a char * buffer.
+ * @note This function can be used to copy a string literal without
+ * MISRA warnings.
+ *
+ * @param[in] destination The buffer to write
+ * @param[in] source String to copy.
+ * @param[in] length Number of characters to copy.
+ * @return @p length
+ */
+static size_t copyString( char * destination,
+                          const char * source,
+                          size_t length );
+
 /*-----------------------------------------------------------*/
 
 static void intToAscii( int32_t value,
@@ -994,6 +1008,18 @@ static size_t sizeNeededForCredentialScope( const SigV4Parameters_t * pSigV4Para
            CREDENTIAL_SCOPE_SEPARATOR_LEN + CREDENTIAL_SCOPE_TERMINATOR_LEN;
 }
 
+/*-----------------------------------------------------------*/
+
+static size_t copyString( char * destination,
+                          const char * source,
+                          size_t length )
+{
+    ( void ) memcpy( destination, source, length );
+    return length;
+}
+
+/*-----------------------------------------------------------*/
+
 static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
                                               SigV4String_t * pCredScope )
 {
@@ -1043,8 +1069,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
         pBufWrite += CREDENTIAL_SCOPE_SEPARATOR_LEN;
 
         /* Concatenate terminator. */
-        ( void ) memcpy( pBufWrite, CREDENTIAL_SCOPE_TERMINATOR, CREDENTIAL_SCOPE_TERMINATOR_LEN );
-        pBufWrite += CREDENTIAL_SCOPE_TERMINATOR_LEN;
+        pBufWrite += copyString( pBufWrite, CREDENTIAL_SCOPE_TERMINATOR, CREDENTIAL_SCOPE_TERMINATOR_LEN );
 
         assert( ( size_t ) ( pBufWrite - pCredScope->pData ) == sizeNeeded );
         pCredScope->dataLen = sizeNeeded;
@@ -2630,8 +2655,7 @@ static SigV4Status_t generateAuthorizationValuePrefix( const SigV4Parameters_t *
         numOfBytesWritten += SPACE_CHAR_LEN;
 
         /**************** Write "Credential=<access key ID>/<credential scope>, " ****************/
-        ( void ) memcpy( ( pAuthBuf + numOfBytesWritten ), AUTH_CREDENTIAL_PREFIX, AUTH_CREDENTIAL_PREFIX_LEN );
-        numOfBytesWritten += AUTH_CREDENTIAL_PREFIX_LEN;
+        numOfBytesWritten += copyString( ( pAuthBuf + numOfBytesWritten ), AUTH_CREDENTIAL_PREFIX, AUTH_CREDENTIAL_PREFIX_LEN );
         ( void ) memcpy( ( pAuthBuf + numOfBytesWritten ),
                          pParams->pCredentials->pAccessKeyId,
                          pParams->pCredentials->accessKeyIdLen );
@@ -2646,23 +2670,19 @@ static SigV4Status_t generateAuthorizationValuePrefix( const SigV4Parameters_t *
         numOfBytesWritten += credentialScope.dataLen;
 
         /* Add separator before the Signed Headers information. */
-        ( void ) memcpy( pAuthBuf + numOfBytesWritten, AUTH_SEPARATOR, AUTH_SEPARATOR_LEN );
-        numOfBytesWritten += AUTH_SEPARATOR_LEN;
+        numOfBytesWritten += copyString( pAuthBuf + numOfBytesWritten, AUTH_SEPARATOR, AUTH_SEPARATOR_LEN );
 
 
         /************************ Write "SignedHeaders=<signedHeaders>, " *******************************/
-        ( void ) memcpy( pAuthBuf + numOfBytesWritten, AUTH_SIGNED_HEADERS_PREFIX, AUTH_SIGNED_HEADERS_PREFIX_LEN );
-        numOfBytesWritten += AUTH_SIGNED_HEADERS_PREFIX_LEN;
+        numOfBytesWritten += copyString( pAuthBuf + numOfBytesWritten, AUTH_SIGNED_HEADERS_PREFIX, AUTH_SIGNED_HEADERS_PREFIX_LEN );
         ( void ) memcpy( pAuthBuf + numOfBytesWritten, pSignedHeaders, signedHeadersLen );
         numOfBytesWritten += signedHeadersLen;
 
         /* Add separator before the Signature field name. */
-        ( void ) memcpy( pAuthBuf + numOfBytesWritten, AUTH_SEPARATOR, AUTH_SEPARATOR_LEN );
-        numOfBytesWritten += AUTH_SEPARATOR_LEN;
+        numOfBytesWritten += copyString( pAuthBuf + numOfBytesWritten, AUTH_SEPARATOR, AUTH_SEPARATOR_LEN );
 
         /****************************** Write "Signature=<signature>" *******************************/
-        ( void ) memcpy( pAuthBuf + numOfBytesWritten, AUTH_SIGNATURE_PREFIX, AUTH_SIGNATURE_PREFIX_LEN );
-        numOfBytesWritten += AUTH_SIGNATURE_PREFIX_LEN;
+        numOfBytesWritten += copyString( pAuthBuf + numOfBytesWritten, AUTH_SIGNATURE_PREFIX, AUTH_SIGNATURE_PREFIX_LEN );
 
         /* END: Writing of authorization value prefix. */
 

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -632,10 +632,15 @@ static size_t sizeNeededForCredentialScope( const SigV4Parameters_t * pSigV4Para
  * @note This function can be used to copy a string literal without
  * MISRA warnings.
  *
+ * @note This function assumes the destination buffer is large enough to hold
+ * the string to copy, so will always write @p length bytes.
+ *
  * @param[in] destination The buffer to write.
  * @param[in] source String to copy.
  * @param[in] length Number of characters to copy.
- * @return @p length
+ *
+ * @return @p length The number of characters written from @p source into
+ * @p destination.
  */
 static size_t copyString( char * destination,
                           const char * source,

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -1400,7 +1400,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
         {
             /* If the header field is not in canonical form already, we need to check
              * whether this character represents a trimmable space. */
-            if( !( flags & SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) &&
+            if( !FLAG_IS_SET( flags, SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) &&
                 isTrimmableSpace( pData, index, dataLen, numOfBytesCopied ) )
             {
                 /* Cannot copy trimmable space into canonical request buffer. */
@@ -1572,7 +1572,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
             }
             /* Look for header value part of a header field entry for both canonicalized and non-canonicalized forms. */
             /* Non-canonicalized headers will have header values ending with "\r\n". */
-            else if( ( !keyFlag ) && !( flags & SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) && ( ( index + 1U ) < headersDataLen ) &&
+            else if( ( !keyFlag ) && !FLAG_IS_SET( flags, SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) && ( ( index + 1U ) < headersDataLen ) &&
                      ( 0 == strncmp( pCurrLoc, "\r\n", strlen( "\r\n" ) ) ) )
             {
                 canonicalRequest->pHeadersLoc[ noOfHeaders ].value.pData = pKeyOrValStartLoc;
@@ -1583,7 +1583,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
                 noOfHeaders++;
             }
             /* Canonicalized headers will have header values ending just with "\n". */
-            else if( ( !keyFlag ) && ( ( flags & SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) && ( pHeaders[ index ] == '\n' ) ) )
+            else if( ( !keyFlag ) && ( FLAG_IS_SET( flags, SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) && ( pHeaders[ index ] == '\n' ) ) )
             {
                 canonicalRequest->pHeadersLoc[ noOfHeaders ].value.pData = pKeyOrValStartLoc;
                 canonicalRequest->pHeadersLoc[ noOfHeaders ].value.dataLen = ( pCurrLoc - pKeyOrValStartLoc );
@@ -1631,7 +1631,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
                                                   &noOfHeaders,
                                                   canonicalRequest );
 
-        if( ( sigV4Status == SigV4Success ) && !( flags & SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) )
+        if( ( sigV4Status == SigV4Success ) && !FLAG_IS_SET( flags, SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) )
         {
             /* Sorting headers based on keys. */
             qsort( canonicalRequest->pHeadersLoc, noOfHeaders, sizeof( SigV4KeyValuePair_t ), cmpHeaderField );
@@ -1642,7 +1642,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
         }
 
         /* The \n character must be written if provided headers are not already canonicalized. */
-        if( ( sigV4Status == SigV4Success ) && !( flags & SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) )
+        if( ( sigV4Status == SigV4Success ) && !FLAG_IS_SET( flags, SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) )
         {
             if( canonicalRequest->bufRemaining < 1U )
             {
@@ -2503,7 +2503,7 @@ static SigV4Status_t generateCanonicalRequestUntilHeaders( const SigV4Parameters
     if( returnStatus == SigV4Success )
     {
         /* Write the URI to the canonical request. */
-        if( pParams->pHttpParameters->flags & SIGV4_HTTP_PATH_IS_CANONICAL_FLAG )
+        if( FLAG_IS_SET( pParams->pHttpParameters->flags, SIGV4_HTTP_PATH_IS_CANONICAL_FLAG ) )
         {
             /* URI is already canonicalized, so just write it to the buffer as is. */
             returnStatus = writeLineToCanonicalRequest( pPath,
@@ -2529,7 +2529,7 @@ static SigV4Status_t generateCanonicalRequestUntilHeaders( const SigV4Parameters
     if( returnStatus == SigV4Success )
     {
         /* Write the query to the canonical request. */
-        if( pParams->pHttpParameters->flags & SIGV4_HTTP_QUERY_IS_CANONICAL_FLAG )
+        if( FLAG_IS_SET( pParams->pHttpParameters->flags, SIGV4_HTTP_QUERY_IS_CANONICAL_FLAG ) )
         {
             /* HTTP query is already canonicalized, so just write it to the buffer as is. */
             returnStatus = writeLineToCanonicalRequest( pParams->pHttpParameters->pQuery,
@@ -2545,7 +2545,7 @@ static SigV4Status_t generateCanonicalRequestUntilHeaders( const SigV4Parameters
     }
 
     if( ( returnStatus == SigV4Success ) &&
-        pParams->pHttpParameters->flags & SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG )
+        FLAG_IS_SET( pParams->pHttpParameters->flags, SIGV4_HTTP_HEADERS_ARE_CANONICAL_FLAG ) )
     {
         /* Headers are already canonicalized, so just write it to the buffer as is. */
         returnStatus = writeLineToCanonicalRequest( pParams->pHttpParameters->pHeaders,

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -1215,7 +1215,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
     static bool isAllowedChar( char c,
                                bool encodeSlash )
     {
-        return( isalnum( c ) || ( c == '-' ) || ( c == '_' ) || ( c == '.' ) || ( c == '~' ) || ( ( c == '/' ) && !encodeSlash ) );
+        return( ( isalnum( c ) != 0U ) || ( c == '-' ) || ( c == '_' ) || ( c == '.' ) || ( c == '~' ) || ( ( c == '/' ) && !encodeSlash ) );
     }
 
 /*-----------------------------------------------------------*/
@@ -1377,7 +1377,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
         assert( ( value != NULL ) && ( index < valLen ) );
 
         /* Only trim spaces. */
-        if( isspace( value[ index ] ) )
+        if( isspace( value[ index ] ) != 0U )
         {
             /* The last character is a trailing space. */
             if( ( index + 1U ) == valLen )
@@ -1385,7 +1385,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
                 ret = true;
             }
             /* Trim if the next character is also a space. */
-            else if( isspace( value[ index + 1U ] ) )
+            else if( isspace( value[ index + 1U ] ) != 0U )
             {
                 ret = true;
             }
@@ -1449,7 +1449,7 @@ static SigV4Status_t generateCredentialScope( const SigV4Parameters_t * pSigV4Pa
                 }
                 else
                 {
-                    *pCurrBufLoc = tolower( pData[ index ] );
+                    *pCurrBufLoc = ( char ) tolower( ( int32_t ) ( uint8_t ) pData[ index ] );
                 }
 
                 pCurrBufLoc++;

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -2125,14 +2125,14 @@ static SigV4Status_t completeHashAndHexEncode( const char * pInput,
     assert( pCryptoInterface->hashUpdate != NULL );
     assert( pCryptoInterface->hashFinal != NULL );
 
-    originalHash.pData = hashBuffer;
+    originalHash.pData = ( char * ) hashBuffer;
     originalHash.dataLen = pCryptoInterface->hashDigestLen;
     hexEncodedHash.pData = pOutput;
     hexEncodedHash.dataLen = *pOutputLen;
 
     if( completeHash( ( const uint8_t * ) pInput,
                       inputLen,
-                      ( uint8_t * ) hashBuffer,
+                      hashBuffer,
                       pCryptoInterface->hashDigestLen,
                       pCryptoInterface ) != 0 )
     {
@@ -2247,7 +2247,7 @@ static int32_t hmacData( HmacContext_t * pHmacContext,
         for( i = 0U; i < pCryptoInterface->hashBlockLen; i++ )
         {
             /* XOR the key with the ipad. */
-            pHmacContext->key[ i ] ^= ( uint8_t ) 0x36;
+            pHmacContext->key[ i ] ^= 0x36U;
         }
 
         returnStatus = pCryptoInterface->hashInit( pCryptoInterface->pHashContext );
@@ -2279,7 +2279,7 @@ static int32_t hmacFinal( HmacContext_t * pHmacContext,
                           size_t macLen )
 {
     int32_t returnStatus = -1;
-    char innerHashDigest[ SIGV4_HASH_MAX_DIGEST_LENGTH ];
+    uint8_t innerHashDigest[ SIGV4_HASH_MAX_DIGEST_LENGTH ];
     size_t i = 0U;
     const SigV4CryptoInterface_t * pCryptoInterface = NULL;
 
@@ -2306,7 +2306,7 @@ static int32_t hmacFinal( HmacContext_t * pHmacContext,
          * inner-padded key with (0x36 ^ 0x5c) = (ipad ^ opad) = 0x6a.  */
         for( i = 0U; i < pCryptoInterface->hashBlockLen; i++ )
         {
-            pHmacContext->key[ i ] ^= ( uint8_t ) ( 0x6a );
+            pHmacContext->key[ i ] ^= 0x6aU;
         }
 
         returnStatus = pCryptoInterface->hashInit( pCryptoInterface->pHashContext );
@@ -2332,7 +2332,7 @@ static int32_t hmacFinal( HmacContext_t * pHmacContext,
     {
         /* Write the final HMAC value. */
         returnStatus = pCryptoInterface->hashFinal( pCryptoInterface->pHashContext,
-                                                    pMac,
+                                                    ( uint8_t * ) pMac,
                                                     macLen );
     }
 


### PR DESCRIPTION
*Description*:
Addresses more warnings from static analysis, mostly due to unsigned/signed/boolean conversions. ~Ignore the first commit until #32 is merged as this PR is based on top of those changes~

- Update some char * to uint8_t *
- Fix 10.4 warnings
- Add macro for bit flags
- Add ptrdiff_t for 10.8 and 10.3 warnings
- Address 7.4 warnings
- Address some ctype warnigs
