### PR TITLE
Remove outdated README information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # AWS IoT SigV4 Library
 
-**Note** This library is currently under development.
-
 The AWS SigV4 Library is a standalone library for generating authorization headers and signatures according to the specifications of the [Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html) signing process. Authorization headers are required for authentication when sending HTTP requests to AWS. This library can optionally be used by applications sending direct HTTP requests to AWS services requiring SigV4 authentication. This library has no dependencies on any additional libraries other than the standard C library. This library is distributed under the MIT Open Source License.
 
 This library has gone through code quality checks including verification that no function has a GNU Complexity score over 8, and checks against deviations from mandatory rules in the MISRA coding standard. Deviations from the MISRA C:2012 guidelines are documented under MISRA Deviations. This library has also undergone static code analysis using Coverity static analysis, and validation of memory safety through the CBMC automated reasoning tool.
@@ -37,7 +35,7 @@ a compile time preprocessor macro.
   
 ## Building the SigV4 Library
 
-The sigV4FilePaths.cmake file contains information of all the source files and header include paths required to build the SigV4 library.
+The [sigV4FilePaths.cmake](sigV4FilePaths.cmake) file contains information of all the source files and header include paths required to build the SigV4 library.
 
 As mentioned in the previous section, either a custom config file (i.e.
 `sigv4_config.h`) or `SIGV4_DO_NOT_USE_CUSTOM_CONFIG`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ a compile time preprocessor macro.
   
 ## Building the SigV4 Library
 
-The [sigV4FilePaths.cmake](sigV4FilePaths.cmake) file contains information of all the source files and header include paths required to build the SigV4 library.
+The [sigv4FilePaths.cmake](sigv4FilePaths.cmake) file contains information of all the source files and header include paths required to build the SigV4 library.
 
 As mentioned in the previous section, either a custom config file (i.e.
 `sigv4_config.h`) or `SIGV4_DO_NOT_USE_CUSTOM_CONFIG`


### PR DESCRIPTION
Library is no longer under development so take it out and is now in maintenance mode so take it out

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
