### PR TITLE
Add C++ guards to SigV4 headers

### DIFF
--- a/source/include/sigv4.h
+++ b/source/include/sigv4.h
@@ -32,6 +32,12 @@
 #include <stdint.h>
 #include <stddef.h>
 
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /* SIGV4_DO_NOT_USE_CUSTOM_CONFIG allows building of the SigV4 library without a
  * config file. If a config file is provided, the SIGV4_DO_NOT_USE_CUSTOM_CONFIG
  * macro must not be defined.
@@ -480,5 +486,11 @@ SigV4Status_t SigV4_AwsIotDateToIso8601( const char * pDate,
                                          char * pDateISO8601,
                                          size_t dateISO8601Len );
 /* @[declare_sigV4_awsIotDateToIso8601_function] */
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* SIGV4_H_ */

--- a/source/include/sigv4_config_defaults.h
+++ b/source/include/sigv4_config_defaults.h
@@ -35,6 +35,12 @@
 #ifndef SIGV4_CONFIG_DEFAULTS_H_
 #define SIGV4_CONFIG_DEFAULTS_H_
 
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /* The macro definition for SIGV4_DO_NOT_USE_CUSTOM_CONFIG is for Doxygen
  * documentation only. */
 
@@ -240,5 +246,11 @@
 #ifndef LogDebug
     #define LogDebug( message )
 #endif
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* ifndef SIGV4_CONFIG_DEFAULTS_H_ */

--- a/source/include/sigv4_internal.h
+++ b/source/include/sigv4_internal.h
@@ -28,6 +28,12 @@
 #ifndef SIGV4_INTERNAL_H_
 #define SIGV4_INTERNAL_H_
 
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /* SIGV4_DO_NOT_USE_CUSTOM_CONFIG allows building of the SigV4 library without a
  * config file. If a config file is provided, the SIGV4_DO_NOT_USE_CUSTOM_CONFIG
  * macro must not be defined.
@@ -222,5 +228,11 @@ typedef struct HmacContext
      */
     size_t keyLen;
 } HmacContext_t;
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* ifndef SIGV4_INTERNAL_H_ */

--- a/source/include/sigv4_quicksort.h
+++ b/source/include/sigv4_quicksort.h
@@ -32,6 +32,12 @@
 #include <stdint.h>
 #include <stddef.h>
 
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /* SIGV4_DO_NOT_USE_CUSTOM_CONFIG allows building of the SigV4 library without a
  * config file. If a config file is provided, the SIGV4_DO_NOT_USE_CUSTOM_CONFIG
  * macro must not be defined.
@@ -67,5 +73,11 @@ void quickSort( void * pArray,
                 size_t numItems,
                 size_t itemSize,
                 ComparisonFunc_t comparator );
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* ifndef SIGV4_QUICKSORT_H_ */


### PR DESCRIPTION
Allows C++ linkage by adding guards to header files

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
