### PR TITLE
Name change from AWS IoT to AWS

### DIFF
--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -1,5 +1,5 @@
 {
-    "lib_name": "AWS IoT SigV4",
+    "lib_name": "AWS SigV4 library",
     "src": [
         "source/sigv4.c",
         "source/sigv4_quicksort.c"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# Changelog for AWS IoT SigV4 Library
+# Changelog for AWS SigV4 Library
 
 ## v1.0.0 (August 2021)
 
-This is the first release of the AWS IoT SigV4 Library.
+This is the first release of the AWS SigV4 Library.

--- a/MISRA.md
+++ b/MISRA.md
@@ -1,6 +1,6 @@
 # MISRA Compliance
 
-The AWS IoT SigV4 Library files conform to the
+The AWS SigV4 Library files conform to the
 [MISRA C:2012](https://www.misra.org.uk)
 guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
 Deviations from the MISRA standard are listed below:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS IoT SigV4 Library
+# AWS SigV4 Library
 
 The AWS SigV4 Library is a standalone library for generating authorization headers and signatures according to the specifications of the [Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html) signing process. Authorization headers are required for authentication when sending HTTP requests to AWS. This library can optionally be used by applications sending direct HTTP requests to AWS services requiring SigV4 authentication. This library has no dependencies on any additional libraries other than the standard C library. This library is distributed under the MIT Open Source License.
 
@@ -8,8 +8,8 @@ See memory requirements for this library [here][memory_table].
 
 [memory_table]: ./docs/doxygen/include/size_table.md
 
-## AWS IoT SigV4 Library Config File
-The AWS IoT SigV4 library exposes build configuration
+## AWS SigV4 Library Config File
+The AWS SigV4 library exposes build configuration
 macros that are required for building the library. A list of all the
 configurations and their default values are defined in
 [sigv4_config_defaults.h][default_config]. To provide custom values for the

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -1,6 +1,6 @@
 <table>
     <tr>
-        <td colspan="3"><center><b>Code Size of AWS SigV4 library(example generated with GCC for ARM Cortex-M)</b></center></td>
+        <td colspan="3"><center><b>Code Size of AWS SigV4 library (example generated with GCC for ARM Cortex-M)</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -1,6 +1,6 @@
 <table>
     <tr>
-        <td colspan="3"><center><b>Code Size of AWS IoT SigV4 (example generated with GCC for ARM Cortex-M)</b></center></td>
+        <td colspan="3"><center><b>Code Size of AWS SigV4 library(example generated with GCC for ARM Cortex-M)</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -1,9 +1,9 @@
 /**
 @mainpage Overview
 @anchor sigv4
-@brief AWS IoT SigV4 Library
+@brief AWS SigV4 Library
 
-The AWS IoT SigV4 Library is a standalone library for generating signatures
+The AWS SigV4 Library is a standalone library for generating signatures
 and authorization headers according to the specifications of the AWS Signature
 Version 4 signing process. This library aids applications in sending direct
 HTTP requests to AWS services requiring SigV4 authentication. The library is
@@ -37,7 +37,7 @@ coverage.
 
 /**
 @page sigv4_config Configurations
-@brief Configurations of the AWS IoT SigV4 Library.
+@brief Configurations of the AWS SigV4 Library.
 <!-- @par configpagestyle allows the @section titles to be styled according to
      style.css -->
 @par configpagestyle
@@ -64,7 +64,7 @@ compiler option such as -D in gcc.
 
 /**
 @page sigv4_functions Functions
-@brief Primary functions of the AWS IoT SigV4 library:<br><br>
+@brief Primary functions of the AWS SigV4 library:<br><br>
 @subpage sigV4_generateHTTPAuthorization_function <br>
 @subpage sigV4_awsIotDateToIso8601_function <br>
 


### PR DESCRIPTION
This PR updates the name of Library  across the repository from AWS IoT SigV4 Library to AWS SigV4 Library


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
