### PR TITLE
Add quicksort source file to memory statistics

### DIFF
--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -1,7 +1,8 @@
 {
     "lib_name": "AWS IoT SigV4",
     "src": [
-        "source/sigv4.c"
+        "source/sigv4.c",
+        "source/sigv4_quicksort.c"
     ],
     "include": [
         "source/include"

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -13,8 +13,13 @@
         <td><center>4.2K</center></td>
     </tr>
     <tr>
+        <td>sigv4_quicksort.c</td>
+        <td><center>0.4K</center></td>
+        <td><center>0.3K</center></td>
+    </tr>
+    <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>4.9K</center></b></td>
-        <td><b><center>4.2K</center></b></td>
+        <td><b><center>5.3K</center></b></td>
+        <td><b><center>4.5K</center></b></td>
     </tr>
 </table>


### PR DESCRIPTION
The quicksort source file was never added to the memory stats config so this adds it now

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
