### PR TITLE
CBMC Proof Failure Fixes

### DIFF
--- a/test/cbmc/include/sigv4_stubs.h
+++ b/test/cbmc/include/sigv4_stubs.h
@@ -66,4 +66,10 @@ SigV4Status_t generateCanonicalAndSignedHeaders( const char * pHeaders,
                                                  char ** pSignedHeaders,
                                                  size_t * pSignedHeadersLen );
 
+SigV4Status_t copyHeaderStringToCanonicalBuffer( const char * pData,
+                                                 size_t dataLen,
+                                                 uint32_t flags,
+                                                 char separator,
+                                                 CanonicalContext_t * canonicalRequest );
+
 #endif /* ifndef SIGV4_STUBS_H_ */

--- a/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/Makefile
+++ b/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/Makefile
@@ -61,4 +61,4 @@ include ../Makefile-json.common
 
 # Substitution command to pass to sed for patching sigv4.c. The
 # characters " and # must be escaped with backslash.
-SIGV4_SED_EXPR = 1s/^/\#include \"sigv4_stubs.h\" /; s/^static //; s/SigV4Status_t (scanValue|encodeURI|generateCanonicalQuery|generateCanonicalAndSignedHeaders)\b/&_/
+SIGV4_SED_EXPR = 1s/^/\#include \"sigv4_stubs.h\" /; s/^static //; s/SigV4Status_t (scanValue|encodeURI|generateCanonicalQuery|generateCanonicalAndSignedHeaders|copyHeaderStringToCanonicalBuffer)\b/&_/

--- a/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/SigV4_GenerateHTTPAuthorization_harness.c
+++ b/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/SigV4_GenerateHTTPAuthorization_harness.c
@@ -50,7 +50,7 @@ void harness()
     /* This property applies to all hash functions. */
     if( pCryptoInterface != NULL )
     {
-        __CPROVER_assume( 0U < pCryptoInterface->hashBlockLen && pCryptoInterface->hashBlockLen <= MAX_HASH_BLOCK_LEN );
+        __CPROVER_assume( sizeof( "AWS4" ) < pCryptoInterface->hashBlockLen && pCryptoInterface->hashBlockLen <= MAX_HASH_BLOCK_LEN );
         __CPROVER_assume( 0U < pCryptoInterface->hashDigestLen && pCryptoInterface->hashDigestLen <= MAX_HASH_DIGEST_LEN );
         __CPROVER_assume( pCryptoInterface->hashDigestLen <= pCryptoInterface->hashBlockLen );
         pCryptoInterface->hashInit = nondet_bool() ? NULL : HashInitStub;
@@ -75,6 +75,7 @@ void harness()
         __CPROVER_assume( pHttpParams->pathLen < MAX_URI_LEN );
         __CPROVER_assume( pHttpParams->queryLen < MAX_QUERY_LEN );
         __CPROVER_assume( pHttpParams->headersLen < MAX_HEADERS_LEN );
+        __CPROVER_assume( pHttpParams->pPayload != NULL );
         pHttpParams->pPayload = malloc( pHttpParams->payloadLen );
         pHttpParams->pHttpMethod = malloc( pHttpParams->httpMethodLen );
         pHttpParams->pPath = malloc( pHttpParams->pathLen );

--- a/test/cbmc/stubs/sigv4_stubs.c
+++ b/test/cbmc/stubs/sigv4_stubs.c
@@ -229,3 +229,30 @@ SigV4Status_t generateCanonicalAndSignedHeaders( const char * pHeaders,
 
     return returnStatus;
 }
+
+SigV4Status_t copyHeaderStringToCanonicalBuffer( const char * pData,
+                                                 size_t dataLen,
+                                                 uint32_t flags,
+                                                 char separator,
+                                                 CanonicalContext_t * canonicalRequest )
+{
+    SigV4Status_t returnStatus = SigV4Success;
+    size_t buffRemaining;
+
+    __CPROVER_assume( pData != NULL );
+    __CPROVER_assume( dataLen > 0 );
+    __CPROVER_assume( dataLen < CBMC_MAX_OBJECT_SIZE );
+
+    assert( ( pData != NULL ) && ( dataLen > 0 ) );
+    assert( canonicalRequest != NULL );
+    assert( canonicalRequest->pBufCur != NULL );
+
+    buffRemaining = canonicalRequest->bufRemaining;
+
+    if( buffRemaining < dataLen )
+    {
+        returnStatus = SigV4InsufficientMemory;
+    }
+
+    return returnStatus;
+}


### PR DESCRIPTION
This PR updates the GenerateHTTPAuthHeader API CBMC Proof after the payload optimization changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
