### PR TITLE
Remove superfluous memmove

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -29,6 +29,7 @@ const
 constness
 copydoc
 copyheaderstringtocanonicalbuffer
+credentialscope
 crypto
 cryptointerface
 css
@@ -61,6 +62,7 @@ gr
 hashblocklen
 hashcontext
 hashdigestlen
+hashedcanonicalrequest
 hashfinal
 hashinit
 hashpayloadlen
@@ -206,6 +208,7 @@ quicksort
 rande
 readloc
 regionlen
+requestdatetime
 rfc
 sdk
 sec

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -2718,6 +2718,7 @@ static SigV4Status_t writeStringToSign( const SigV4Parameters_t * pParams,
     ptrdiff_t bufferLen = pCanonicalContext->pBufCur - pBufStart;
     /* An overestimate but sufficient memory is checked before proceeding. */
     size_t encodedLen = SIGV4_PROCESSING_BUFFER_LENGTH;
+
     /* The string to sign is composed of (+ means string concatenation):
      * Algorithm + \n +
      * RequestDateTime + \n +

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -2718,6 +2718,14 @@ static SigV4Status_t writeStringToSign( const SigV4Parameters_t * pParams,
     ptrdiff_t bufferLen = pCanonicalContext->pBufCur - pBufStart;
     /* An overestimate but sufficient memory is checked before proceeding. */
     size_t encodedLen = SIGV4_PROCESSING_BUFFER_LENGTH;
+    /* The string to sign is composed of (+ means string concatenation):
+     * Algorithm + \n +
+     * RequestDateTime + \n +
+     * CredentialScope + \n +
+     * HashedCanonicalRequest
+     *
+     * The processing buffer is verified beforehand that it has enough
+     * space to hold this string. */
     size_t sizeNeededBeforeHash = algorithmLen + 1U + \
                                   SIGV4_ISO_STRING_LEN + 1U;
 

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -2716,7 +2716,7 @@ static SigV4Status_t writeStringToSign( const SigV4Parameters_t * pParams,
     SigV4Status_t returnStatus = SigV4Success;
     char * pBufStart = ( char * ) pCanonicalContext->pBufProcessing;
     ptrdiff_t bufferLen = pCanonicalContext->pBufCur - pBufStart;
-    /* An overestimate but sufficient memory is checked before executing this block. */
+    /* An overestimate but sufficient memory is checked before proceeding. */
     size_t encodedLen = SIGV4_PROCESSING_BUFFER_LENGTH;
     size_t sizeNeededBeforeHash = algorithmLen + 1U + \
                                   SIGV4_ISO_STRING_LEN + 1U;


### PR DESCRIPTION
The [existing SigV4 library has a copy operation](https://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk/blob/v1.0.0/source/sigv4.c#L2604-L2610) in the internal processing buffer while generating the **String to Sign**. Instead of copying the hex encoded bytes of the Canonical Request data from a mid-location (right after the initial presence of the Canonical Request) to a location where the _string-to-sign_ data can be stored in the beginning of the buffer, the copy operation can be avoided by storing the _string-to-sign_ at the end of the processing buffer which will cause the processing buffer to contain information in of the **String-To-Sign** and **Signing Key** in the `{<signing-key>, <string-to-sign>}` order

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
