### PR TITLE
Enable logging macros in CI checks for SigV4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,18 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           path: ./build/coverage.info
+  build-with-default-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DSIGV4_DO_NOT_USE_CUSTOM_CONFIG'
+          make -C build/ all
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,8 +42,8 @@ target_compile_definitions( coverity_analysis PUBLIC SIGV4_DO_NOT_USE_CUSTOM_CON
 target_compile_options( coverity_analysis PUBLIC -std=c90 )
 
 # SigV4 public include path and test config file
-target_include_directories( coverity_analysis 
-                            PUBLIC 
+target_include_directories( coverity_analysis
+                            PUBLIC
                             ${SIGV4_INCLUDE_PUBLIC_DIRS}
                             "${CMAKE_CURRENT_LIST_DIR}/include" )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,8 +41,11 @@ target_compile_definitions( coverity_analysis PUBLIC SIGV4_DO_NOT_USE_CUSTOM_CON
 # Verify ISO C90 compliance of libray.
 target_compile_options( coverity_analysis PUBLIC -std=c90 )
 
-# SigV4 public include path.
-target_include_directories( coverity_analysis PUBLIC ${SIGV4_INCLUDE_PUBLIC_DIRS} )
+# SigV4 public include path and test config file
+target_include_directories( coverity_analysis 
+                            PUBLIC 
+                            ${SIGV4_INCLUDE_PUBLIC_DIRS}
+                            "${CMAKE_CURRENT_LIST_DIR}/include" )
 
 #  ============================  Test Configuration ============================
 if(${BUILD_UNIT_TESTS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,9 +35,6 @@ include( ${MODULE_ROOT_DIR}/sigv4FilePaths.cmake )
 add_library( coverity_analysis
             ${SIGV4_SOURCES} )
 
-# Build SigV4 library target without custom config dependencies.
-target_compile_definitions( coverity_analysis PUBLIC SIGV4_DO_NOT_USE_CUSTOM_CONFIG=1 )
-
 # Verify ISO C90 compliance of libray.
 target_compile_options( coverity_analysis PUBLIC -std=c90 )
 

--- a/test/cbmc/proofs/Makefile-project-defines
+++ b/test/cbmc/proofs/Makefile-project-defines
@@ -30,6 +30,7 @@ COMPILE_FLAGS += -std=gnu90
 # INCLUDES =
 INCLUDES += -I$(SRCDIR)/test/cbmc/include
 INCLUDES += -I$(SRCDIR)/source/include
+INCLUDES += -I$(SRCDIR)/test/include
 
 # Preprocessor definitions -D...
 # DEFINES =

--- a/test/include/sigv4_config.h
+++ b/test/include/sigv4_config.h
@@ -26,7 +26,7 @@
  */
 
 #ifndef SIGV4_CONFIG_H_
-#define FLEET_PROVISIONING_CONFIG_H_
+#define SIGV4_CONFIG_H_
 
 #include <stdio.h>
 
@@ -38,4 +38,4 @@
 
 #define LogDebug( message )    printf( "Debug: " ); printf message; printf( "\n" )
 
-#endif /* FLEET_PROVISIONING_CONFIG_H_ */
+#endif /* SIGV4_CONFIG_H_ */

--- a/test/include/sigv4_config.h
+++ b/test/include/sigv4_config.h
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
- /**
+/**
  * @file sigv4_config.h
  * @brief Config values for testing the SigV4 for AWS IoT Library.
  */
@@ -39,4 +39,3 @@
 #define LogDebug( message )    printf( "Debug: " ); printf message; printf( "\n" )
 
 #endif /* FLEET_PROVISIONING_CONFIG_H_ */
-	

--- a/test/include/sigv4_config.h
+++ b/test/include/sigv4_config.h
@@ -1,0 +1,42 @@
+/*
+ * SigV4 Library v1.0.0
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+ /**
+ * @file sigv4_config.h
+ * @brief Config values for testing the SigV4 for AWS IoT Library.
+ */
+
+#ifndef SIGV4_CONFIG_H_
+#define FLEET_PROVISIONING_CONFIG_H_
+
+#include <stdio.h>
+
+#define LogError( message )    printf( "Error: " ); printf message; printf( "\n" )
+
+#define LogWarn( message )     printf( "Warn: " ); printf message; printf( "\n" )
+
+#define LogInfo( message )     printf( "Info: " ); printf message; printf( "\n" )
+
+#define LogDebug( message )    printf( "Debug: " ); printf message; printf( "\n" )
+
+#endif /* FLEET_PROVISIONING_CONFIG_H_ */
+	

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND real_source_files
 list(APPEND real_include_directories
             .
             ${SIGV4_INCLUDE_PUBLIC_DIRS}
+            "${CMAKE_CURRENT_LIST_DIR}/../include"
         )
 
 # =====================  Create UnitTest Code here (edit)  =====================


### PR DESCRIPTION
Fix all unit testing and CBMC to use a custom config that enables logging and tests using printf. Adds a new CI check to ensure no config builds still are tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.