### PR TITLE
Remove extraneous parentheses in isAllowedChar()

### DIFF
--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -1300,7 +1300,7 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
         {
             ret = true;
         }
-        else if( ( c == '/' ) )
+        else if( c == '/' )
         {
             ret = !encodeSlash;
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To fix a build warning below:

```
  warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
          else if( ( c == '/' ) )
                     ~~^~~~~~
  note: remove extraneous parentheses around the comparison to silence this warning
          else if( ( c == '/' ) )
                   ~~  ^      ~~
  note: use '=' to turn this equality comparison into an assignment
          else if( ( c == '/' ) )
                       ^~
                       =
```

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.