### PR TITLE
fix array index off-by-one error in canonical parameter value generation

### DIFF
--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -1378,7 +1378,7 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
                 }
                 else
                 {
-                    bytesConsumed += writeHexCodeOfChar( pCanonicalURI + bytesConsumed, bufferLen - bytesConsumed, pUri[ uriIndex - 1U ] );
+                    bytesConsumed += writeHexCodeOfChar( pCanonicalURI + bytesConsumed, bufferLen - bytesConsumed, pUri[ uriIndex ] );
                 }
             }
 


### PR DESCRIPTION
Hi,
I noticed the canonical generation of http query parameter values were not converting the special characters correctly.  This should fix that.  I hope you can add tests around this use case in the future.
Thanks,
Ben Schoeler
Fortune Brands Home & Security

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
