### PR TITLE
Replace private API encodeURI with public API SigV4_EncodeURI

### DIFF
--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -41,25 +41,6 @@
 #if ( SIGV4_USE_CANONICAL_SUPPORT == 1 )
 
 /**
- * @brief Normalize a URI string according to RFC 3986 and fill destination
- * buffer with the formatted string.
- *
- * @param[in] pUri The URI string to encode.
- * @param[in] uriLen Length of pUri.
- * @param[out] pCanonicalURI The resulting canonicalized URI.
- * @param[in, out] canonicalURILen input: the length of pCanonicalURI,
- * output: the length of the generated canonical URI.
- * @param[in] encodeSlash Option to indicate if slashes should be encoded.
- * @param[in] doubleEncodeEquals Option to indicate if equals should be double-encoded.
- */
-    static SigV4Status_t encodeURI( const char * pUri,
-                                    size_t uriLen,
-                                    char * pCanonicalURI,
-                                    size_t * canonicalURILen,
-                                    bool encodeSlash,
-                                    bool doubleEncodeEquals );
-
-/**
  * @brief Canonicalize the full URI path. The input URI starts after the
  * HTTP host and ends at the question mark character ("?") that begins the
  * query string parameters (if any). Example: folder/subfolder/item.txt"
@@ -1320,18 +1301,6 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
 /*-----------------------------------------------------------*/
 
     SigV4Status_t SigV4_EncodeURI( const char * pUri,
-                                   size_t uriLen,
-                                   char * pCanonicalURI,
-                                   size_t * canonicalURILen,
-                                   bool encodeSlash,
-                                   bool doubleEncodeEquals )
-    {
-        return encodeURI( pUri, uriLen, pCanonicalURI, canonicalURILen, encodeSlash, doubleEncodeEquals );
-    }
-
-/*-----------------------------------------------------------*/
-
-    static SigV4Status_t encodeURI( const char * pUri,
                                     size_t uriLen,
                                     char * pCanonicalURI,
                                     size_t * canonicalURILen,
@@ -1430,7 +1399,7 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
         /* If the canonical URI needs to be encoded twice, then we encode once here,
          * and again at the end of the buffer. Afterwards, the second encode is copied
          * to overwrite the first one. */
-        returnStatus = encodeURI( pUri, uriLen, ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex ] ), &encodedLen, false, false );
+        returnStatus = SigV4_EncodeURI( pUri, uriLen, ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex ] ), &encodedLen, false, false );
 
         if( returnStatus == SigV4Success )
         {
@@ -1442,7 +1411,7 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
                  * written to a different position in the buffer. It should not be done
                  * at an overlapping position of the single-encoded URI. Once written,
                  * the double-encoded URI is moved to the starting location of the single-encoded URI. */
-                returnStatus = encodeURI( ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex ] ),
+                returnStatus = SigV4_EncodeURI( ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex ] ),
                                           encodedLen,
                                           ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex + encodedLen ] ),
                                           &doubleEncodedLen,
@@ -2089,7 +2058,7 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
             /* Encode parameter value if non-empty. Query parameters can have empty values. */
             if( valueLen > 0U )
             {
-                returnStatus = encodeURI( pValue,
+                returnStatus = SigV4_EncodeURI( pValue,
                                           valueLen,
                                           &( pBufCur[ 1 ] ),
                                           &valueBytesWritten,
@@ -2128,7 +2097,7 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
             assert( pCanonicalRequest->pQueryLoc[ paramsIndex ].key.dataLen > 0U );
 
             encodedLen = remainingLen;
-            returnStatus = encodeURI( pCanonicalRequest->pQueryLoc[ paramsIndex ].key.pData,
+            returnStatus = SigV4_EncodeURI( pCanonicalRequest->pQueryLoc[ paramsIndex ].key.pData,
                                       pCanonicalRequest->pQueryLoc[ paramsIndex ].key.dataLen,
                                       ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex ] ),
                                       &encodedLen,

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -1301,11 +1301,11 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
 /*-----------------------------------------------------------*/
 
     SigV4Status_t SigV4_EncodeURI( const char * pUri,
-                                    size_t uriLen,
-                                    char * pCanonicalURI,
-                                    size_t * canonicalURILen,
-                                    bool encodeSlash,
-                                    bool doubleEncodeEquals )
+                                   size_t uriLen,
+                                   char * pCanonicalURI,
+                                   size_t * canonicalURILen,
+                                   bool encodeSlash,
+                                   bool doubleEncodeEquals )
     {
         size_t uriIndex = 0U, bytesConsumed = 0U;
         size_t bufferLen = 0U;
@@ -1412,11 +1412,11 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
                  * at an overlapping position of the single-encoded URI. Once written,
                  * the double-encoded URI is moved to the starting location of the single-encoded URI. */
                 returnStatus = SigV4_EncodeURI( ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex ] ),
-                                          encodedLen,
-                                          ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex + encodedLen ] ),
-                                          &doubleEncodedLen,
-                                          false,
-                                          false );
+                                                encodedLen,
+                                                ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex + encodedLen ] ),
+                                                &doubleEncodedLen,
+                                                false,
+                                                false );
 
                 if( returnStatus == SigV4Success )
                 {
@@ -2059,11 +2059,11 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
             if( valueLen > 0U )
             {
                 returnStatus = SigV4_EncodeURI( pValue,
-                                          valueLen,
-                                          &( pBufCur[ 1 ] ),
-                                          &valueBytesWritten,
-                                          true /* Encode slash (/) */,
-                                          doubleEncodeEqualsInParmsValues );
+                                                valueLen,
+                                                &( pBufCur[ 1 ] ),
+                                                &valueBytesWritten,
+                                                true /* Encode slash (/) */,
+                                                doubleEncodeEqualsInParmsValues );
 
                 if( returnStatus == SigV4Success )
                 {
@@ -2098,11 +2098,11 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
 
             encodedLen = remainingLen;
             returnStatus = SigV4_EncodeURI( pCanonicalRequest->pQueryLoc[ paramsIndex ].key.pData,
-                                      pCanonicalRequest->pQueryLoc[ paramsIndex ].key.dataLen,
-                                      ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex ] ),
-                                      &encodedLen,
-                                      true /* Encode slash (/) */,
-                                      false /* Do not double encode '='. */ );
+                                            pCanonicalRequest->pQueryLoc[ paramsIndex ].key.dataLen,
+                                            ( char * ) &( pCanonicalRequest->pBufProcessing[ uxBufIndex ] ),
+                                            &encodedLen,
+                                            true /* Encode slash (/) */,
+                                            false /* Do not double encode '='. */ );
 
             if( returnStatus == SigV4Success )
             {

--- a/test/cbmc/include/sigv4_stubs.h
+++ b/test/cbmc/include/sigv4_stubs.h
@@ -50,7 +50,7 @@ SigV4Status_t writeLineToCanonicalRequest( const char * pLine,
                                            size_t lineLen,
                                            CanonicalContext_t * pCanonicalContext );
 
-SigV4Status_t encodeURI( const char * pUri,
+SigV4Status_t SigV4_EncodeURI( const char * pUri,
                          size_t uriLen,
                          char * pCanonicalURI,
                          size_t * canonicalURILen,

--- a/test/cbmc/include/sigv4_stubs.h
+++ b/test/cbmc/include/sigv4_stubs.h
@@ -51,11 +51,11 @@ SigV4Status_t writeLineToCanonicalRequest( const char * pLine,
                                            CanonicalContext_t * pCanonicalContext );
 
 SigV4Status_t SigV4_EncodeURI( const char * pUri,
-                         size_t uriLen,
-                         char * pCanonicalURI,
-                         size_t * canonicalURILen,
-                         bool encodeSlash,
-                         bool doubleEncodeEquals );
+                               size_t uriLen,
+                               char * pCanonicalURI,
+                               size_t * canonicalURILen,
+                               bool encodeSlash,
+                               bool doubleEncodeEquals );
 
 SigV4Status_t generateCanonicalQuery( const char * pQuery,
                                       size_t queryLen,

--- a/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/Makefile
+++ b/test/cbmc/proofs/SigV4_GenerateHTTPAuthorization/Makefile
@@ -63,4 +63,4 @@ include ../Makefile-json.common
 
 # Substitution command to pass to sed for patching sigv4.c. The
 # characters " and # must be escaped with backslash.
-SIGV4_SED_EXPR = 1s/^/\#include \"sigv4_stubs.h\" /; s/^static //; s/SigV4Status_t (scanValue|encodeURI|generateCanonicalQuery|generateCanonicalAndSignedHeaders|copyHeaderStringToCanonicalBuffer)\b/&_/
+SIGV4_SED_EXPR = 1s/^/\#include \"sigv4_stubs.h\" /; s/^static //; s/SigV4Status_t (scanValue|SigV4_EncodeURI|generateCanonicalQuery|generateCanonicalAndSignedHeaders|copyHeaderStringToCanonicalBuffer)\b/&_/

--- a/test/cbmc/stubs/sigv4_stubs.c
+++ b/test/cbmc/stubs/sigv4_stubs.c
@@ -147,7 +147,7 @@ SigV4Status_t writeLineToCanonicalRequest( const char * pLine,
     return ret;
 }
 
-SigV4Status_t encodeURI( const char * pUri,
+SigV4Status_t SigV4_EncodeURI( const char * pUri,
                          size_t uriLen,
                          char * pCanonicalURI,
                          size_t * canonicalURILen,

--- a/test/cbmc/stubs/sigv4_stubs.c
+++ b/test/cbmc/stubs/sigv4_stubs.c
@@ -148,11 +148,11 @@ SigV4Status_t writeLineToCanonicalRequest( const char * pLine,
 }
 
 SigV4Status_t SigV4_EncodeURI( const char * pUri,
-                         size_t uriLen,
-                         char * pCanonicalURI,
-                         size_t * canonicalURILen,
-                         bool encodeSlash,
-                         bool doubleEncodeEquals )
+                               size_t uriLen,
+                               char * pCanonicalURI,
+                               size_t * canonicalURILen,
+                               bool encodeSlash,
+                               bool doubleEncodeEquals )
 {
     SigV4Status_t returnStatus = SigV4Success;
 

--- a/test/unit-test/sigv4_utest.c
+++ b/test/unit-test/sigv4_utest.c
@@ -693,7 +693,7 @@ void test_SigV4_GenerateHTTPAuthorization_Happy_Paths()
     returnStatus = SigV4_GenerateHTTPAuthorization( &params, authBuf, &authBufLen, &signature, &signatureLen );
     TEST_ASSERT_EQUAL( SigV4Success, returnStatus );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%ld\n.*%s\n", authBufLen, authBuf );
+    printf( "%.*s\n", ( int )( authBufLen ), authBuf );
 
     /* Coverage for the case where the service name has the same length as "s3". */
     params.serviceLen = S3_SERVICE_NAME_LEN;
@@ -701,7 +701,7 @@ void test_SigV4_GenerateHTTPAuthorization_Happy_Paths()
     returnStatus = SigV4_GenerateHTTPAuthorization( &params, authBuf, &authBufLen, &signature, &signatureLen );
     TEST_ASSERT_EQUAL( SigV4Success, returnStatus );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%ld\n.*%s\n", authBufLen, authBuf );
+    printf( "%.*s\n", ( int )( authBufLen ), authBuf );
 
     /* Coverage for the null-terminated path. */
     resetInputParams();
@@ -797,7 +797,7 @@ void test_SigV4_GenerateAuthorization_Query_Strings_Special_Cases()
     TEST_ASSERT_EQUAL( SigV4Success, SigV4_GenerateHTTPAuthorization(
                            &params, authBuf, &authBufLen, &signature, &signatureLen ) );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%ld\n.*%s\n", authBufLen, authBuf );
+    printf( "%.*s\n", ( int )( authBufLen ), authBuf );
     TEST_ASSERT_EQUAL_MEMORY( pExpectedSignature, signature, signatureLen );
 
     params.pHttpParameters->pQuery = QUERY_STRING_WITH_TRAILING_N_LEADING_AMPERSAND;

--- a/test/unit-test/sigv4_utest.c
+++ b/test/unit-test/sigv4_utest.c
@@ -1412,7 +1412,7 @@ void test_SigV4_GenerateAuthorization_Header_Key_Or_Value_With_All_White_Spaces(
     free( longHeader );
 }
 
-/* Test to add SigV4_EncodeURI API to achieve full coverage. */
+/* Test that the public API SigV4_EncodeURI API of the library returns expected result to achieve full coverage. */
 void test_SigV4_EncodeURI()
 {
     SigV4Status_t returnStatus;

--- a/test/unit-test/sigv4_utest.c
+++ b/test/unit-test/sigv4_utest.c
@@ -245,7 +245,7 @@ static int32_t valid_sha256_final( void * pHashContext,
                                    uint8_t * pOutput,
                                    size_t outputLen )
 {
-    ( void )outputLen;
+    ( void ) outputLen;
 
     if( SHA256_Final( ( uint8_t * ) pOutput, ( SHA256_CTX * ) pHashContext ) )
     {
@@ -265,7 +265,7 @@ static size_t finalHashCalledCount = 0U, finalHashCallToFail = SIZE_MAX;
 
 static int32_t hash_init_failable( void * pHashContext )
 {
-    ( void )pHashContext;
+    ( void ) pHashContext;
 
     int32_t ret = 0;
 
@@ -281,9 +281,9 @@ static int32_t hash_update_failable( void * pHashContext,
                                      const uint8_t * pInput,
                                      size_t inputLen )
 {
-    ( void )pHashContext;
-    ( void )pInput;
-    ( void )inputLen;
+    ( void ) pHashContext;
+    ( void ) pInput;
+    ( void ) inputLen;
 
     int32_t ret = 0;
 
@@ -299,9 +299,9 @@ static int32_t hash_final_failable( void * pHashContext,
                                     uint8_t * pOutput,
                                     size_t outputLen )
 {
-    ( void )pHashContext;
-    ( void )pOutput;
-    ( void )outputLen;
+    ( void ) pHashContext;
+    ( void ) pOutput;
+    ( void ) outputLen;
 
     int32_t ret = 0;
 
@@ -1416,7 +1416,8 @@ void test_SigV4_GenerateAuthorization_Header_Key_Or_Value_With_All_White_Spaces(
 void test_SigV4_EncodeURI()
 {
     SigV4Status_t returnStatus;
+
     resetInputParams();
     returnStatus = SigV4_EncodeURI( params.pHttpParameters->pPath, params.pHttpParameters->pathLen, authBuf, &authBufLen, true, true );
-    TEST_ASSERT_EQUAL( SigV4Success, returnStatus ); 
+    TEST_ASSERT_EQUAL( SigV4Success, returnStatus );
 }

--- a/test/unit-test/sigv4_utest.c
+++ b/test/unit-test/sigv4_utest.c
@@ -245,6 +245,8 @@ static int32_t valid_sha256_final( void * pHashContext,
                                    uint8_t * pOutput,
                                    size_t outputLen )
 {
+    ( void )outputLen;
+
     if( SHA256_Final( ( uint8_t * ) pOutput, ( SHA256_CTX * ) pHashContext ) )
     {
         return 0;
@@ -263,6 +265,8 @@ static size_t finalHashCalledCount = 0U, finalHashCallToFail = SIZE_MAX;
 
 static int32_t hash_init_failable( void * pHashContext )
 {
+    ( void )pHashContext;
+
     int32_t ret = 0;
 
     if( hashInitCalledCount++ == hashInitCallToFail )
@@ -277,6 +281,10 @@ static int32_t hash_update_failable( void * pHashContext,
                                      const uint8_t * pInput,
                                      size_t inputLen )
 {
+    ( void )pHashContext;
+    ( void )pInput;
+    ( void )inputLen;
+
     int32_t ret = 0;
 
     if( updateHashCalledCount++ == updateHashCallToFail )
@@ -291,6 +299,10 @@ static int32_t hash_final_failable( void * pHashContext,
                                     uint8_t * pOutput,
                                     size_t outputLen )
 {
+    ( void )pHashContext;
+    ( void )pOutput;
+    ( void )outputLen;
+
     int32_t ret = 0;
 
     if( finalHashCalledCount++ == finalHashCallToFail )
@@ -681,7 +693,7 @@ void test_SigV4_GenerateHTTPAuthorization_Happy_Paths()
     returnStatus = SigV4_GenerateHTTPAuthorization( &params, authBuf, &authBufLen, &signature, &signatureLen );
     TEST_ASSERT_EQUAL( SigV4Success, returnStatus );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%.*s\n", authBufLen, authBuf );
+    printf( "%ld\n.*%s\n", authBufLen, authBuf );
 
     /* Coverage for the case where the service name has the same length as "s3". */
     params.serviceLen = S3_SERVICE_NAME_LEN;
@@ -689,7 +701,7 @@ void test_SigV4_GenerateHTTPAuthorization_Happy_Paths()
     returnStatus = SigV4_GenerateHTTPAuthorization( &params, authBuf, &authBufLen, &signature, &signatureLen );
     TEST_ASSERT_EQUAL( SigV4Success, returnStatus );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%.*s\n", authBufLen, authBuf );
+    printf( "%ld\n.*%s\n", authBufLen, authBuf );
 
     /* Coverage for the null-terminated path. */
     resetInputParams();
@@ -785,7 +797,7 @@ void test_SigV4_GenerateAuthorization_Query_Strings_Special_Cases()
     TEST_ASSERT_EQUAL( SigV4Success, SigV4_GenerateHTTPAuthorization(
                            &params, authBuf, &authBufLen, &signature, &signatureLen ) );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%.*s\n", authBufLen, authBuf );
+    printf( "%ld\n.*%s\n", authBufLen, authBuf );
     TEST_ASSERT_EQUAL_MEMORY( pExpectedSignature, signature, signatureLen );
 
     params.pHttpParameters->pQuery = QUERY_STRING_WITH_TRAILING_N_LEADING_AMPERSAND;

--- a/test/unit-test/sigv4_utest.c
+++ b/test/unit-test/sigv4_utest.c
@@ -1399,3 +1399,12 @@ void test_SigV4_GenerateAuthorization_Header_Key_Or_Value_With_All_White_Spaces(
     TEST_ASSERT_EQUAL( SigV4InvalidParameter, returnStatus );
     free( longHeader );
 }
+
+/* Test to add SigV4_EncodeURI API to achieve full coverage. */
+void test_SigV4_EncodeURI()
+{
+    SigV4Status_t returnStatus;
+    resetInputParams();
+    returnStatus = SigV4_EncodeURI( params.pHttpParameters->pPath, params.pHttpParameters->pathLen, authBuf, &authBufLen, true, true );
+    TEST_ASSERT_EQUAL( SigV4Success, returnStatus ); 
+}

--- a/test/unit-test/sigv4_utest.c
+++ b/test/unit-test/sigv4_utest.c
@@ -693,7 +693,7 @@ void test_SigV4_GenerateHTTPAuthorization_Happy_Paths()
     returnStatus = SigV4_GenerateHTTPAuthorization( &params, authBuf, &authBufLen, &signature, &signatureLen );
     TEST_ASSERT_EQUAL( SigV4Success, returnStatus );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%.*s\n", ( int )( authBufLen ), authBuf );
+    printf( "%.*s\n", ( int ) ( authBufLen ), authBuf );
 
     /* Coverage for the case where the service name has the same length as "s3". */
     params.serviceLen = S3_SERVICE_NAME_LEN;
@@ -701,7 +701,7 @@ void test_SigV4_GenerateHTTPAuthorization_Happy_Paths()
     returnStatus = SigV4_GenerateHTTPAuthorization( &params, authBuf, &authBufLen, &signature, &signatureLen );
     TEST_ASSERT_EQUAL( SigV4Success, returnStatus );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%.*s\n", ( int )( authBufLen ), authBuf );
+    printf( "%.*s\n", ( int ) ( authBufLen ), authBuf );
 
     /* Coverage for the null-terminated path. */
     resetInputParams();
@@ -797,7 +797,7 @@ void test_SigV4_GenerateAuthorization_Query_Strings_Special_Cases()
     TEST_ASSERT_EQUAL( SigV4Success, SigV4_GenerateHTTPAuthorization(
                            &params, authBuf, &authBufLen, &signature, &signatureLen ) );
     TEST_ASSERT_EQUAL( SIGV4_HASH_MAX_DIGEST_LENGTH * 2U, signatureLen );
-    printf( "%.*s\n", ( int )( authBufLen ), authBuf );
+    printf( "%.*s\n", ( int ) ( authBufLen ), authBuf );
     TEST_ASSERT_EQUAL_MEMORY( pExpectedSignature, signature, signatureLen );
 
     params.pHttpParameters->pQuery = QUERY_STRING_WITH_TRAILING_N_LEADING_AMPERSAND;
@@ -1410,14 +1410,4 @@ void test_SigV4_GenerateAuthorization_Header_Key_Or_Value_With_All_White_Spaces(
     returnStatus = SigV4_GenerateHTTPAuthorization( &params, authBuf, &authBufLen, &signature, &signatureLen );
     TEST_ASSERT_EQUAL( SigV4InvalidParameter, returnStatus );
     free( longHeader );
-}
-
-/* Test that the public API SigV4_EncodeURI API of the library returns expected result to achieve full coverage. */
-void test_SigV4_EncodeURI()
-{
-    SigV4Status_t returnStatus;
-
-    resetInputParams();
-    returnStatus = SigV4_EncodeURI( params.pHttpParameters->pPath, params.pHttpParameters->pathLen, authBuf, &authBufLen, true, true );
-    TEST_ASSERT_EQUAL( SigV4Success, returnStatus );
 }


### PR DESCRIPTION
Description
-----------
This PR removes the redundant private API `encodeURI` with public API `SigV4_EncodeURI` introduced in #89 .

Test Steps
-----------
```
cmake -S test -B build/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DUNITTEST=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -DNDEBUG -DLOGGING_LEVEL_DEBUG=1'
cd build/
make coverage
cd ..
declare -a EXCLUDE=("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")
echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
lcov --rc lcov_branch_coverage=1 --list build/coverage.info
```
Before applying the patch
```
Summary coverage rate:
  lines......: 99.8% (931 of 933 lines)
  functions..: 98.2% (54 of 55 functions)
  branches...: 100.0% (497 of 497 branches)
Reading tracefile build/coverage.info
                         |Lines       |Functions  |Branches    
Filename                 |Rate     Num|Rate    Num|Rate     Num
===============================================================
[/home/ubuntu/Temp/kar-rahul-aws/karahulx_SigV4/SigV4-for-AWS-IoT-embedded-sdk/source/]
sigv4.c                  |99.8%    886|98.0%    51| 100%    475
sigv4_quicksort.c        | 100%     47| 100%     4| 100%     22
===============================================================
                   Total:|99.8%    933|98.2%    55| 100%    497
```
After applying the patch
```
Summary coverage rate:
  lines......: 100.0% (933 of 933 lines)
  functions..: 100.0% (55 of 55 functions)
  branches...: 100.0% (497 of 497 branches)
Reading tracefile build/coverage.info
                         |Lines       |Functions  |Branches    
Filename                 |Rate     Num|Rate    Num|Rate     Num
===============================================================
[/home/ubuntu/Temp/kar-rahul-aws/karahulx_SigV4/SigV4-for-AWS-IoT-embedded-sdk/source/]
sigv4.c                  | 100%    886| 100%    51| 100%    475
sigv4_quicksort.c        | 100%     47| 100%     4| 100%     22
===============================================================
                   Total:| 100%    933| 100%    55| 100%    497
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#89

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
