### PR TITLE
Update SigV4_EncodeURI in doxygen

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -2257,7 +2257,7 @@ MACRO_EXPANSION        = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = YES
+EXPAND_ONLY_PREDEF     = NO
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -72,6 +72,7 @@ compiler option such as -D in gcc.
 @brief Primary functions of the AWS SigV4 library:<br><br>
 @subpage sigV4_generateHTTPAuthorization_function <br>
 @subpage sigV4_awsIotDateToIso8601_function <br>
+@subpage sigV4_encodeURI_function <br>
 
 @page sigV4_generateHTTPAuthorization_function SigV4_GenerateHTTPAuthorization
 @snippet sigv4.h declare_sigV4_generateHTTPAuthorization_function
@@ -80,6 +81,10 @@ compiler option such as -D in gcc.
 @page sigV4_awsIotDateToIso8601_function SigV4_AwsIotDateToIso8601
 @snippet sigv4.h declare_sigV4_awsIotDateToIso8601_function
 @copydoc SigV4_AwsIotDateToIso8601
+
+@page sigV4_encodeURI_function SigV4_EncodeURI
+@snippet sigv4.h declare_sigV4_encodeURI_function
+@copydoc SigV4_EncodeURI
 */
 
 <!-- We do not use doxygen ALIASes here because there have been issues in the past versions with "^^" newlines within the alias definition. -->

--- a/source/include/sigv4.h
+++ b/source/include/sigv4.h
@@ -156,6 +156,8 @@ typedef enum SigV4Status
      * Functions that may return this value:
      * - #SigV4_GenerateHTTPAuthorization
      * - #SigV4_AwsIotDateToIso8601
+     * - #SigV4_EncodeURI
+     * 
      */
     SigV4Success,
 
@@ -175,6 +177,7 @@ typedef enum SigV4Status
      *
      * Functions that may return this value:
      * - #SigV4_GenerateHTTPAuthorization
+     * - #SigV4_EncodeURI
      */
     SigV4InsufficientMemory,
 
@@ -575,8 +578,6 @@ SigV4Status_t SigV4_AwsIotDateToIso8601( const char * pDate,
                                          size_t dateISO8601Len );
 /* @[declare_sigV4_awsIotDateToIso8601_function] */
 
-#if ( SIGV4_USE_CANONICAL_SUPPORT == 1 )
-
 /**
  * @brief Normalize a URI string according to RFC 3986 and fill destination
  * buffer with the formatted string.
@@ -588,17 +589,17 @@ SigV4Status_t SigV4_AwsIotDateToIso8601( const char * pDate,
  * output: the length of the generated canonical URI.
  * @param[in] encodeSlash Option to indicate if slashes should be encoded.
  * @param[in] doubleEncodeEquals Option to indicate if equals should be double-encoded.
+ *
+ * @return #SigV4Success code if successful, error code otherwise.
  */
-/* @[declare_sigV4_EncodeURI_function] */
-    SigV4Status_t SigV4_EncodeURI( const char * pUri,
-                                   size_t uriLen,
-                                   char * pCanonicalURI,
-                                   size_t * canonicalURILen,
-                                   bool encodeSlash,
-                                   bool doubleEncodeEquals );
 /* @[declare_sigV4_encodeURI_function] */
-
-#endif /* #if (SIGV4_USE_CANONICAL_SUPPORT == 1) */
+SigV4Status_t SigV4_EncodeURI( const char * pUri,
+                               size_t uriLen,
+                               char * pCanonicalURI,
+                               size_t * canonicalURILen,
+                               bool encodeSlash,
+                               bool doubleEncodeEquals );
+/* @[declare_sigV4_encodeURI_function] */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/sigv4.h
+++ b/source/include/sigv4.h
@@ -157,7 +157,6 @@ typedef enum SigV4Status
      * - #SigV4_GenerateHTTPAuthorization
      * - #SigV4_AwsIotDateToIso8601
      * - #SigV4_EncodeURI
-     * 
      */
     SigV4Success,
 

--- a/source/include/sigv4.h
+++ b/source/include/sigv4.h
@@ -577,6 +577,8 @@ SigV4Status_t SigV4_AwsIotDateToIso8601( const char * pDate,
                                          size_t dateISO8601Len );
 /* @[declare_sigV4_awsIotDateToIso8601_function] */
 
+#if ( SIGV4_USE_CANONICAL_SUPPORT == 1 )
+
 /**
  * @brief Normalize a URI string according to RFC 3986 and fill destination
  * buffer with the formatted string.
@@ -592,13 +594,15 @@ SigV4Status_t SigV4_AwsIotDateToIso8601( const char * pDate,
  * @return #SigV4Success code if successful, error code otherwise.
  */
 /* @[declare_sigV4_encodeURI_function] */
-SigV4Status_t SigV4_EncodeURI( const char * pUri,
-                               size_t uriLen,
-                               char * pCanonicalURI,
-                               size_t * canonicalURILen,
-                               bool encodeSlash,
-                               bool doubleEncodeEquals );
+    SigV4Status_t SigV4_EncodeURI( const char * pUri,
+                                   size_t uriLen,
+                                   char * pCanonicalURI,
+                                   size_t * canonicalURILen,
+                                   bool encodeSlash,
+                                   bool doubleEncodeEquals );
 /* @[declare_sigV4_encodeURI_function] */
+
+#endif /* #if (SIGV4_USE_CANONICAL_SUPPORT == 1) */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -1300,87 +1300,6 @@ static void generateCredentialScope( const SigV4Parameters_t * pSigV4Params,
 
 /*-----------------------------------------------------------*/
 
-    SigV4Status_t SigV4_EncodeURI( const char * pUri,
-                                   size_t uriLen,
-                                   char * pCanonicalURI,
-                                   size_t * canonicalURILen,
-                                   bool encodeSlash,
-                                   bool doubleEncodeEquals )
-    {
-        size_t uriIndex = 0U, bytesConsumed = 0U;
-        size_t bufferLen = 0U;
-        SigV4Status_t returnStatus = SigV4Success;
-
-        assert( pUri != NULL );
-        assert( pCanonicalURI != NULL );
-        assert( canonicalURILen != NULL );
-
-        bufferLen = *canonicalURILen;
-
-        while( ( uriIndex < uriLen ) && ( returnStatus == SigV4Success ) )
-        {
-            if( doubleEncodeEquals && ( pUri[ uriIndex ] == '=' ) )
-            {
-                if( ( bufferLen - bytesConsumed ) < URI_DOUBLE_ENCODED_EQUALS_CHAR_SIZE )
-                {
-                    returnStatus = SigV4InsufficientMemory;
-                    LOG_INSUFFICIENT_MEMORY_ERROR( "double encode '=' character in canonical query",
-                                                   ( bytesConsumed + URI_DOUBLE_ENCODED_EQUALS_CHAR_SIZE - bufferLen ) );
-                }
-                else
-                {
-                    bytesConsumed += writeDoubleEncodedEquals( &( pCanonicalURI[ bytesConsumed ] ), bufferLen - bytesConsumed );
-                }
-            }
-            else if( isAllowedChar( pUri[ uriIndex ], encodeSlash ) )
-            {
-                /* If the output buffer has space, add the character as-is in URI encoding as it
-                 * is neither a special character nor an '=' character requiring double encoding. */
-                if( bytesConsumed < bufferLen )
-                {
-                    pCanonicalURI[ bytesConsumed ] = pUri[ uriIndex ];
-                    ++bytesConsumed;
-                }
-                else
-                {
-                    returnStatus = SigV4InsufficientMemory;
-                    LogError( ( "Failed to encode URI in buffer due to insufficient memory" ) );
-                }
-            }
-            else if( pUri[ uriIndex ] == '\0' )
-            {
-                /* The URI path beyond the NULL terminator is not encoded. */
-                uriIndex = uriLen;
-            }
-            else
-            {
-                if( ( bufferLen - bytesConsumed ) < URI_ENCODED_SPECIAL_CHAR_SIZE )
-                {
-                    returnStatus = SigV4InsufficientMemory;
-                    LOG_INSUFFICIENT_MEMORY_ERROR( "encode special character in canonical URI",
-                                                   ( bytesConsumed + URI_ENCODED_SPECIAL_CHAR_SIZE - bufferLen ) );
-                }
-                else
-                {
-                    bytesConsumed += writeHexCodeOfChar( &( pCanonicalURI[ bytesConsumed ] ), bufferLen - bytesConsumed, pUri[ uriIndex ] );
-                }
-            }
-
-            uriIndex++;
-        }
-
-        if( returnStatus == SigV4Success )
-        {
-            /* Set the output parameter of the number of URI encoded bytes written
-             * to the buffer. */
-            *canonicalURILen = bytesConsumed;
-        }
-
-        return returnStatus;
-    }
-
-/*-----------------------------------------------------------*/
-
     static SigV4Status_t generateCanonicalURI( const char * pUri,
                                                size_t uriLen,
                                                bool encodeTwice,
@@ -2408,6 +2327,8 @@ static SigV4Status_t completeHashAndHexEncode( const char * pInput,
     return returnStatus;
 }
 
+/*-----------------------------------------------------------*/
+
 static int32_t hmacAddKey( HmacContext_t * pHmacContext,
                            const char * pKey,
                            size_t keyLen,
@@ -2598,6 +2519,8 @@ static int32_t hmacFinal( HmacContext_t * pHmacContext,
     return returnStatus;
 }
 
+/*-----------------------------------------------------------*/
+
 static SigV4Status_t writeLineToCanonicalRequest( const char * pLine,
                                                   size_t lineLen,
                                                   CanonicalContext_t * pCanonicalContext )
@@ -2627,6 +2550,8 @@ static SigV4Status_t writeLineToCanonicalRequest( const char * pLine,
 
     return returnStatus;
 }
+
+/*-----------------------------------------------------------*/
 
 static int32_t completeHmac( HmacContext_t * pHmacContext,
                              const char * pKey,
@@ -2664,6 +2589,8 @@ static int32_t completeHmac( HmacContext_t * pHmacContext,
     return returnStatus;
 }
 
+/*-----------------------------------------------------------*/
+
 static size_t writeStringToSignPrefix( char * pBufStart,
                                        const char * pAlgorithm,
                                        size_t algorithmLen,
@@ -2692,6 +2619,8 @@ static size_t writeStringToSignPrefix( char * pBufStart,
 
     return algorithmLen + 1U + SIGV4_ISO_STRING_LEN + 1U;
 }
+
+/*-----------------------------------------------------------*/
 
 static SigV4Status_t writeStringToSign( const SigV4Parameters_t * pParams,
                                         const char * pAlgorithm,
@@ -2770,6 +2699,8 @@ static SigV4Status_t writeStringToSign( const SigV4Parameters_t * pParams,
 
     return returnStatus;
 }
+
+/*-----------------------------------------------------------*/
 
 static SigV4Status_t generateCanonicalRequestUntilHeaders( const SigV4Parameters_t * pParams,
                                                            CanonicalContext_t * pCanonicalContext,
@@ -2869,6 +2800,7 @@ static SigV4Status_t generateCanonicalRequestUntilHeaders( const SigV4Parameters
     return returnStatus;
 }
 
+/*-----------------------------------------------------------*/
 
 static SigV4Status_t generateAuthorizationValuePrefix( const SigV4Parameters_t * pParams,
                                                        const char * pAlgorithm,
@@ -2961,6 +2893,7 @@ static SigV4Status_t generateAuthorizationValuePrefix( const SigV4Parameters_t *
     return returnStatus;
 }
 
+/*-----------------------------------------------------------*/
 
 static SigV4Status_t generateSigningKey( const SigV4Parameters_t * pSigV4Params,
                                          HmacContext_t * pHmacContext,
@@ -3062,6 +2995,8 @@ static SigV4Status_t generateSigningKey( const SigV4Parameters_t * pSigV4Params,
     return returnStatus;
 }
 
+/*-----------------------------------------------------------*/
+
 static SigV4Status_t writePayloadHashToCanonicalRequest( const SigV4Parameters_t * pParams,
                                                          CanonicalContext_t * pCanonicalContext )
 {
@@ -3101,6 +3036,7 @@ static SigV4Status_t writePayloadHashToCanonicalRequest( const SigV4Parameters_t
     return returnStatus;
 }
 
+/*-----------------------------------------------------------*/
 
 SigV4Status_t SigV4_AwsIotDateToIso8601( const char * pDate,
                                          size_t dateLen,
@@ -3177,6 +3113,8 @@ SigV4Status_t SigV4_AwsIotDateToIso8601( const char * pDate,
 
     return returnStatus;
 }
+
+/*-----------------------------------------------------------*/
 
 SigV4Status_t SigV4_GenerateHTTPAuthorization( const SigV4Parameters_t * pParams,
                                                char * pAuthBuf,
@@ -3286,3 +3224,86 @@ SigV4Status_t SigV4_GenerateHTTPAuthorization( const SigV4Parameters_t * pParams
 
     return returnStatus;
 }
+
+/*-----------------------------------------------------------*/
+
+SigV4Status_t SigV4_EncodeURI( const char * pUri,
+                               size_t uriLen,
+                               char * pCanonicalURI,
+                               size_t * canonicalURILen,
+                               bool encodeSlash,
+                               bool doubleEncodeEquals )
+{
+    size_t uriIndex = 0U, bytesConsumed = 0U;
+    size_t bufferLen = 0U;
+    SigV4Status_t returnStatus = SigV4Success;
+
+    assert( pUri != NULL );
+    assert( pCanonicalURI != NULL );
+    assert( canonicalURILen != NULL );
+
+    bufferLen = *canonicalURILen;
+
+    while( ( uriIndex < uriLen ) && ( returnStatus == SigV4Success ) )
+    {
+        if( doubleEncodeEquals && ( pUri[ uriIndex ] == '=' ) )
+        {
+            if( ( bufferLen - bytesConsumed ) < URI_DOUBLE_ENCODED_EQUALS_CHAR_SIZE )
+            {
+                returnStatus = SigV4InsufficientMemory;
+                LOG_INSUFFICIENT_MEMORY_ERROR( "double encode '=' character in canonical query",
+                                               ( bytesConsumed + URI_DOUBLE_ENCODED_EQUALS_CHAR_SIZE - bufferLen ) );
+            }
+            else
+            {
+                bytesConsumed += writeDoubleEncodedEquals( &( pCanonicalURI[ bytesConsumed ] ), bufferLen - bytesConsumed );
+            }
+        }
+        else if( isAllowedChar( pUri[ uriIndex ], encodeSlash ) )
+        {
+            /* If the output buffer has space, add the character as-is in URI encoding as it
+             * is neither a special character nor an '=' character requiring double encoding. */
+            if( bytesConsumed < bufferLen )
+            {
+                pCanonicalURI[ bytesConsumed ] = pUri[ uriIndex ];
+                ++bytesConsumed;
+            }
+            else
+            {
+                returnStatus = SigV4InsufficientMemory;
+                LogError( ( "Failed to encode URI in buffer due to insufficient memory" ) );
+            }
+        }
+        else if( pUri[ uriIndex ] == '\0' )
+        {
+            /* The URI path beyond the NULL terminator is not encoded. */
+            uriIndex = uriLen;
+        }
+        else
+        {
+            if( ( bufferLen - bytesConsumed ) < URI_ENCODED_SPECIAL_CHAR_SIZE )
+            {
+                returnStatus = SigV4InsufficientMemory;
+                LOG_INSUFFICIENT_MEMORY_ERROR( "encode special character in canonical URI",
+                                               ( bytesConsumed + URI_ENCODED_SPECIAL_CHAR_SIZE - bufferLen ) );
+            }
+            else
+            {
+                bytesConsumed += writeHexCodeOfChar( &( pCanonicalURI[ bytesConsumed ] ), bufferLen - bytesConsumed, pUri[ uriIndex ] );
+            }
+        }
+
+        uriIndex++;
+    }
+
+    if( returnStatus == SigV4Success )
+    {
+        /* Set the output parameter of the number of URI encoded bytes written
+         * to the buffer. */
+        *canonicalURILen = bytesConsumed;
+    }
+
+    return returnStatus;
+}
+
+/*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------
This PR adds `SigV4_EncodeURI` in Functions List in doxygen. It disables `EXPAND_ONLY_PREDEF` in `config.doxyfile` to allow macro expansion of `SIGV4_USE_CANONICAL_SUPPORT`.

Test Steps
-----------
Compiled and Ran doxygen to see the desired output
```
doxygen docs/doxygen/config.doxyfile
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
