### PR TITLE
Move deref to after non-null assert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           path: ./
 
   formatting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.event.issue.pull_request &&
         ( ( github.event.comment.body == '/bot run uncrustify' ) ||
           ( github.event.comment.body == '/bot run formatting' ) ) }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Apply Formatting Fix
       uses: FreeRTOS/CI-CD-Github-Actions/formatting-bot@main

--- a/source/sigv4.c
+++ b/source/sigv4.c
@@ -2408,7 +2408,7 @@ static int32_t hmacIntermediate( HmacContext_t * pHmacContext,
 {
     int32_t returnStatus = 0;
     size_t i = 0U;
-    const SigV4CryptoInterface_t * pCryptoInterface = pHmacContext->pCryptoInterface;
+    const SigV4CryptoInterface_t * pCryptoInterface;
 
     assert( pHmacContext != NULL );
     assert( dataLen > 0U );
@@ -2417,7 +2417,9 @@ static int32_t hmacIntermediate( HmacContext_t * pHmacContext,
     assert( pHmacContext->pCryptoInterface->hashInit != NULL );
     assert( pHmacContext->pCryptoInterface->hashUpdate != NULL );
     assert( pHmacContext->pCryptoInterface->hashFinal != NULL );
-    assert( pHmacContext->keyLen == pCryptoInterface->hashBlockLen );
+    assert( pHmacContext->keyLen == pHmacContext->pCryptoInterface->hashBlockLen );
+
+    pCryptoInterface = pHmacContext->pCryptoInterface;
 
     /* Derive the inner HMAC key by XORing the key with inner pad byte. */
     for( i = 0U; i < pCryptoInterface->hashBlockLen; i++ )


### PR DESCRIPTION
Asserting afterwards triggers a GCC static analysis error:

```
source/sigv4.c:2413:5: warning: check of ‘pHmacContext_22(D)’ for NULL after already dereferencing it [-Wanalyzer-deref-before-check]
 2413 |     assert( pHmacContext != NULL );
      |     ^
  ‘hmacIntermediate’: events 1-2
    |
    | 2411 |     const SigV4CryptoInterface_t * pCryptoInterface = pHmacContext->pCryptoInterface;
    |      |                                    ^
    |      |                                    |
    |      |                                    (1) pointer ‘pHmacContext_22(D)’ is dereferenced here
    | 2412 |
    | 2413 |     assert( pHmacContext != NULL );
    |      |     ~
    |      |     |
    |      |     (2) pointer ‘pHmacContext_22(D)’ is checked for NULL here but it was already dereferenced at (1)
    |
```